### PR TITLE
Handle missing users with custom exception

### DIFF
--- a/src/main/java/com/example/mybackend/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/mybackend/exception/GlobalExceptionHandler.java
@@ -2,7 +2,6 @@ package com.example.mybackend.exception;
 
 import java.time.LocalDateTime;
 import java.util.Map;
-import java.util.NoSuchElementException;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.converter.HttpMessageNotReadableException;
@@ -15,23 +14,23 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
-    //this will catch errors where we are trying to update those values that dont exist via put
-    @ResponseStatus(HttpStatus.BAD_REQUEST)
-    @ExceptionHandler(NoSuchElementException.class)
-    public ApiErrorResponse handleNoSuchApiErrorResponse(NoSuchElementException ex) {
-        Map<String, String> errorDetails = Map.of("message", ex.getMessage()+ "better luck next time");
+    // handle not found user
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    @ExceptionHandler(UserNotFoundException.class)
+    public ApiErrorResponse handleUserNotFound(UserNotFoundException ex) {
+        Map<String, String> errorDetails = Map.of("message", ex.getMessage());
 
         return new ApiErrorResponse(
             LocalDateTime.now(),
-            HttpStatus.BAD_REQUEST.value(),
-            "Bad Request",
+            HttpStatus.NOT_FOUND.value(),
+            "Not Found",
             errorDetails
         );
     }
 
     //handle invalid json
     @ResponseStatus(HttpStatus.BAD_REQUEST)
-    @ExceptionHandler(org.springframework.http.converter.HttpMessageNotReadableException.class)
+    @ExceptionHandler(HttpMessageNotReadableException.class)
     public ApiErrorResponse handleInvalidJson(HttpMessageNotReadableException ex) {
         return new ApiErrorResponse(
             LocalDateTime.now(),

--- a/src/main/java/com/example/mybackend/exception/UserNotFoundException.java
+++ b/src/main/java/com/example/mybackend/exception/UserNotFoundException.java
@@ -1,0 +1,11 @@
+package com.example.mybackend.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.NOT_FOUND)
+public class UserNotFoundException extends RuntimeException {
+    public UserNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/example/mybackend/service/UserService.java
+++ b/src/main/java/com/example/mybackend/service/UserService.java
@@ -8,7 +8,7 @@ import com.example.mybackend.repository.UserRepository;
 import com.example.mybackend.dto.CreateUserRequestDTO;
 import com.example.mybackend.dto.UserResponseDTO;
 import com.example.mybackend.model.User;
-import java.util.*;
+import com.example.mybackend.exception.UserNotFoundException;
 
 @Service
 public class UserService {
@@ -32,7 +32,7 @@ public class UserService {
 
     public UserResponseDTO getUserByID(int id){
         User user = userRepository.findById(id)
-        .orElseThrow(()-> new NoSuchElementException("User Not found with id" + id));
+        .orElseThrow(() -> new UserNotFoundException("User not found with id" + id));
         
         return new UserResponseDTO(user.getId(), user.getName());
     }
@@ -47,7 +47,7 @@ public class UserService {
 
     public UserResponseDTO updateUser(int id, CreateUserRequestDTO userUpdate){
         User existingUser =  userRepository.findById(id)
-        .orElseThrow(()-> new NoSuchElementException("User not found with id" + id));
+        .orElseThrow(() -> new UserNotFoundException("User not found with id" + id));
 
         existingUser.setName(userUpdate.getName());
         User saved = userRepository.save(existingUser);
@@ -56,7 +56,7 @@ public class UserService {
 
     public void deleteUser(int id){
         if(!userRepository.existsById(id)){
-            throw new NoSuchElementException("User not found with id" + id);
+            throw new UserNotFoundException("User not found with id" + id);
         }
         userRepository.deleteById(id);
     }


### PR DESCRIPTION
## Summary
- add `UserNotFoundException` annotated with 404
- throw `UserNotFoundException` in `UserService` for absent IDs
- map `UserNotFoundException` in `GlobalExceptionHandler` to 404 error responses

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a6ae8b42f48322b69c501073505dbf