### PR TITLE
docs: add setup and usage details to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,53 @@
 # my-backend-lab
-Learning java
+
+A simple Spring Boot backend used for learning Java and building REST APIs.
+It ships with an in-memory H2 database and OpenAPI/Swagger documentation.
+
+## Prerequisites
+- [Java Development Kit (JDK) 17+](https://adoptium.net/)
+- [Maven](https://maven.apache.org/) 3.x (the provided `mvnw` wrapper can be used instead)
+
+## Running the application
+Use the Maven wrapper to start the application:
+
+```bash
+./mvnw spring-boot:run
+```
+
+The server starts on port **8080** by default. You can also build a runnable jar:
+
+```bash
+./mvnw clean package
+java -jar target/mybackend-0.0.1-SNAPSHOT.jar
+```
+
+## Running tests
+Execute the project's tests with:
+
+```bash
+./mvnw test
+```
+
+## API documentation and consoles
+- Swagger UI: [http://localhost:8080/swagger-ui/index.html](http://localhost:8080/swagger-ui/index.html)
+- H2 database console: [http://localhost:8080/h2-console](http://localhost:8080/h2-console) (user `sa`, blank password)
+
+## Environment configuration
+Configuration defaults are defined in `src/main/resources/application.properties`:
+
+```
+spring.datasource.url=jdbc:h2:mem:testdb
+spring.h2.console.enabled=true
+```
+
+To customize settings such as the server port or database connection, edit that file or supply properties at runtime:
+
+```bash
+# change the server port
+./mvnw spring-boot:run -Dspring-boot.run.arguments=--server.port=9090
+
+# use a file-based H2 database
+./mvnw spring-boot:run -Dspring-boot.run.arguments="--spring.datasource.url=jdbc:h2:file:~/mydb"
+```
+
+For additional options, consult the [Spring Boot documentation](https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/).


### PR DESCRIPTION
## Summary
- document prerequisites, run steps, and testing commands
- explain Swagger UI, H2 console, and configuration options

## Testing
- `./mvnw test` *(fails: wget failed to fetch Maven dependencies)*
- `apt-get update` *(fails: repository not signed/403)*

------
https://chatgpt.com/codex/tasks/task_e_68a6b6a956808322a654f61b1638b0cd